### PR TITLE
Added option to customise icon when there are no bookmarks

### DIFF
--- a/config/zeus-delia.php
+++ b/config/zeus-delia.php
@@ -15,6 +15,7 @@ return [
     'dropdown' => [
         'title' => 'Bookmarks',
         'icon' => 'heroicon-m-bookmark-square',
+        'empty_icon' => 'heroicon-m-bookmark-slash'
     ],
 
     /**

--- a/resources/views/filament/hooks/topbar.blade.php
+++ b/resources/views/filament/hooks/topbar.blade.php
@@ -7,14 +7,14 @@
     <x-filament::dropdown>
         <x-slot name="trigger">
             <x-filament::icon-button size="lg"
-                :icon="config('zeus-delia.dropdown.icon')"
+                :icon="config('zeus-delia.dropdown.icon', 'heroicon-m-bookmark-square')"
             >
                 {{ config('zeus-delia.dropdown.title') }}
             </x-filament::icon-button>
         </x-slot>
 
         @if($bookmarks->isEmpty())
-            <x-filament::dropdown.header :icon="config('zeus-delia.dropdown.empty_icon')">
+            <x-filament::dropdown.header :icon="config('zeus-delia.dropdown.empty_icon', 'heroicon-m-bookmark-slash')">
                 No Bookmarks found
             </x-filament::dropdown.header>
         @else

--- a/resources/views/filament/hooks/topbar.blade.php
+++ b/resources/views/filament/hooks/topbar.blade.php
@@ -14,7 +14,7 @@
         </x-slot>
 
         @if($bookmarks->isEmpty())
-            <x-filament::dropdown.header icon="tabler-bookmark-off">
+            <x-filament::dropdown.header :icon="config('zeus-delia.dropdown.empty_icon')">
                 No Bookmarks found
             </x-filament::dropdown.header>
         @else


### PR DESCRIPTION
Installing the package in a base filament app causes an error when the tabler blade icon package is not installed.

This pull request does the following:
- Sets the default icon when there are no bookmarks to a icon from the heroicon set which comes with filament as standard.
- Allows the developer to customise the empty icon from the config file.

Many thanks!