### PR TITLE
Don't show the bookmark in table widgets, causes an error

### DIFF
--- a/resources/views/filament/hooks/table-column-bookmark.blade.php
+++ b/resources/views/filament/hooks/table-column-bookmark.blade.php
@@ -11,21 +11,23 @@
         @endif
     @endif
 
-    @if($class instanceof \Filament\Resources\RelationManagers\RelationManager)
-        @php
-            $title = $class->getTable()->getHeading();
-            $icon = '';
-        @endphp
-    @else
-        @php
-            $title = $class::getNavigationLabel();
-            $icon = $class::getNavigationIcon();
-        @endphp
-    @endif
+    @if(!($class instanceof \Filament\Widgets\TableWidget))
+        @if($class instanceof \Filament\Resources\RelationManagers\RelationManager)
+            @php
+                $title = $class->getTable()->getHeading();
+                $icon = '';
+            @endphp
+        @else
+            @php
+                $title = $class::getNavigationLabel();
+                $icon = $class::getNavigationIcon();
+            @endphp
+        @endif
 
-    <livewire:delia-bookmarks
-        :url="request()->fullUrl()"
-        :title="$title"
-        :icon="$icon"
-    />
+        <livewire:delia-bookmarks
+            :url="request()->fullUrl()"
+            :title="$title"
+            :icon="$icon"
+        />
+    @endif
 </div>


### PR DESCRIPTION
When a table widget is added, the plugin tries to add the bookmark icon but fails as it does not have the necessary methods required.

Bookmark action is no longer shown on widget tables, as this doesn't really make sense anyways.